### PR TITLE
eksctl-anywhere must be run from eksctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,24 +242,21 @@ We've now provided the `eksa-admin` machine with all of the variables and config
    > **Note**
    > The remaining steps assume you have logged into `eksa-admin` with the SSH command shown above.
 
-1. [Install `eksctl-anywhere`](https://anywhere.eks.amazonaws.com/docs/getting-started/install/#install-eks-anywhere-cli-tools) on eksa-admin.
+1. [Install `eksctl` and the `eksctl-anywhere` plugin](https://anywhere.eks.amazonaws.com/docs/getting-started/install/#install-eks-anywhere-cli-tools) on eksa-admin.
 
    ```sh
-   # eksctl-anywhere plugin for eksctl. this can be run standalone.
+   curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+      --silent --location \
+      | tar xz -C /tmp
+   sudo mv /tmp/eksctl /usr/local/bin/
+   ```
+
+   ```sh
    export EKSA_RELEASE="0.10.1" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=15
    curl "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/${RELEASE_NUMBER}/artifacts/eks-a/v${EKSA_RELEASE}/${OS}/amd64/eksctl-anywhere-v${EKSA_RELEASE}-${OS}-amd64.tar.gz" \
       --silent --location \
       | tar xz ./eksctl-anywhere
    sudo mv ./eksctl-anywhere /usr/local/bin/
-   ```
-
-   ```sh
-   # eksctl is not strictly required for this guide, but can be expected
-   # for `eksctl anywhere` commands you may find in other guides.
-   curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
-      --silent --location \
-      | tar xz -C /tmp
-   sudo mv /tmp/eksctl /usr/local/bin/
    ```
 
 1. Install `kubectl` on eksa-admin:
@@ -298,7 +295,7 @@ We've now provided the `eksa-admin` machine with all of the variables and config
    export TINKERBELL_HOST_IP=$LC_TINK_VIP
    export CLUSTER_NAME="${USER}-${RANDOM}"
    export TINKERBELL_PROVIDER=true
-   eksctl-anywhere generate clusterconfig $CLUSTER_NAME --provider tinkerbell > $CLUSTER_NAME.yaml
+   eksctl anywhere generate clusterconfig $CLUSTER_NAME --provider tinkerbell > $CLUSTER_NAME.yaml
    ```
 
    > **Note**
@@ -366,13 +363,13 @@ We've now provided the `eksa-admin` machine with all of the variables and config
 1. Create an EKS-A Cluster. Double check and be sure `$LC_POOL_ADMIN` and `$CLUSTER_NAME` are set correctly before running this (they were passed through SSH or otherwise defined in previous steps). Otherwise manually set them!
 
    ```sh
-   eksctl-anywhere create cluster --filename $CLUSTER_NAME.yaml \
+   eksctl anywhere create cluster --filename $CLUSTER_NAME.yaml \
      --hardware-csv hardware.csv --tinkerbell-bootstrap-ip $LC_POOL_ADMIN
    ```
 
-### Steps to run locally while eksctl-anywhere is creating the cluster
+### Steps to run locally while `eksctl anywhere` is creating the cluster
 
-1. When the command above indicates it's waiting for the control plane node, reboot the two nodes. This is to force them attempt to iPXE boot from the tinkerbell stack that eksctl-anywhere command creates. You can use this command to automate it, but you'll need to be back on the original host.
+1. When the command above indicates it's waiting for the control plane node, reboot the two nodes. This is to force them attempt to iPXE boot from the tinkerbell stack that `eksctl anywhere` command creates. You can use this command to automate it, but you'll need to be back on the original host.
 
    ```sh
    node_ids=$(metal devices list -o json | jq -r '.[] | select(.hostname | startswith("eksa-node")) | .id')

--- a/main.tf
+++ b/main.tf
@@ -260,7 +260,7 @@ resource "null_resource" "create_cluster" {
       "export CLUSTER_CONFIG_FILE=$CLUSTER_NAME.yaml",
       "export PUB_SSH_KEY=\"$(cat /root/.ssh/${local.ssh_key_name}.pub)\"",
       "chmod 400 /root/.ssh/${local.ssh_key_name}.pub",
-      "eksctl-anywhere generate clusterconfig $CLUSTER_NAME --provider tinkerbell > $CLUSTER_CONFIG_FILE",
+      "eksctl anywhere generate clusterconfig $CLUSTER_NAME --provider tinkerbell > $CLUSTER_CONFIG_FILE",
       "cp $CLUSTER_CONFIG_FILE $CLUSTER_CONFIG_FILE.orig",
       "yq e -i \"select(.kind == \\\"Cluster\\\").spec.controlPlaneConfiguration.endpoint.host |= \\\"$CONTROL_PLANE_VIP\\\"\" $CLUSTER_CONFIG_FILE",
       "yq e -i 'select(.kind == \"Cluster\").spec.controlPlaneConfiguration.count |= ${var.cp_device_count}' $CLUSTER_CONFIG_FILE",
@@ -271,7 +271,7 @@ resource "null_resource" "create_cluster" {
       "yq e -i 'select(.kind == \"TinkerbellMachineConfig\").spec.hardwareSelector |= { \"type\": \"HW_TYPE\" }' $CLUSTER_CONFIG_FILE",
       "sed -i '0,/^\\([[:blank:]]*\\)type: HW_TYPE.*$/ s//\\1type: cp/' $CLUSTER_CONFIG_FILE",
       "sed -i '0,/^\\([[:blank:]]*\\)type: HW_TYPE.*$/ s//\\1type: dp/' $CLUSTER_CONFIG_FILE",
-      "eksctl-anywhere create cluster --filename $CLUSTER_CONFIG_FILE --hardware-csv hardware.csv --tinkerbell-bootstrap-ip ${local.pool_admin} 2>&1 | tee -a /root/eksa-create-cluster.log",
+      "eksctl anywhere create cluster --filename $CLUSTER_CONFIG_FILE --hardware-csv hardware.csv --tinkerbell-bootstrap-ip ${local.pool_admin} 2>&1 | tee -a /root/eksa-create-cluster.log",
     ]
   }
 

--- a/setup.cloud-init.tftpl
+++ b/setup.cloud-init.tftpl
@@ -43,6 +43,8 @@ runcmd:
 - export HOME="/root"
 - systemctl restart networking
 - sleep 10
+- curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" --silent --location | tar xz -C /tmp
+- sudo mv /tmp/eksctl /usr/local/bin/
 - export EKSA_RELEASE="0.10.1" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=15
 - curl "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/$RELEASE_NUMBER/artifacts/eks-a/v$EKSA_RELEASE/$OS/amd64/eksctl-anywhere-v$EKSA_RELEASE-$OS-amd64.tar.gz" --silent --location | tar xz ./eksctl-anywhere
 - sudo mv ./eksctl-anywhere /usr/local/bin/


### PR DESCRIPTION
```
null_resource.create_cluster (remote-exec): Installing EKS-A secrets on workload cluster
null_resource.create_cluster (remote-exec): Installing resources on management cluster
null_resource.create_cluster (remote-exec): Moving cluster management from bootstrap to workload cluster
null_resource.create_cluster: Still creating... [9m30s elapsed]
null_resource.create_cluster (remote-exec): Installing EKS-A custom components (CRD and controller) on workload cluster
null_resource.create_cluster: Still creating... [9m40s elapsed]
null_resource.create_cluster (remote-exec): Installing EKS-D components on workload cluster
null_resource.create_cluster (remote-exec): Creating EKS-A CRDs instances on workload cluster
null_resource.create_cluster (remote-exec): Installing AddonManager and GitOps Toolkit on workload cluster
null_resource.create_cluster (remote-exec): GitOps field not specified, bootstrap flux skipped
null_resource.create_cluster (remote-exec): Writing cluster config file
null_resource.create_cluster (remote-exec): Deleting bootstrap cluster
null_resource.create_cluster (remote-exec): 🎉 Cluster created!
null_resource.create_cluster: Creation complete after 9m50s [id=5273820786689416953]

Apply complete! Resources: 19 added, 0 changed, 0 destroyed.

Outputs:
```