### PR TITLE
lab: trim spaces from the plan and metro fields

### DIFF
--- a/examples/lab/main.tf
+++ b/examples/lab/main.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 locals {
-  users = csvdecode(file("users.csv"))
+  users = csvdecode(file(var.csv_file))
 }
 
 data "equinix_metal_organization" "org" {
@@ -22,15 +22,15 @@ data "equinix_metal_organization" "org" {
 }
 
 module "lab" {
-  for_each                 = { for user in local.users : user.email => user }
+  for_each                 = { for user in local.users : trimspace(user.email) => user }
   source                   = "../project-collaborator"
   organization_id          = data.equinix_metal_organization.org.id
   collaborator             = each.value.email
   metal_api_token          = var.metal_api_token
-  metro                    = each.value.metro
-  provisioner_device_type  = each.value.plan
-  cp_device_type           = each.value.plan
-  dp_device_type           = each.value.plan
+  metro                    = trimspace(each.value.metro)
+  provisioner_device_type  = trimspace(each.value.plan)
+  cp_device_type           = trimspace(each.value.plan)
+  dp_device_type           = trimspace(each.value.plan)
   permit_root_ssh_password = var.permit_root_ssh_password
   send_invites             = var.send_invites
 }

--- a/examples/lab/variables.tf
+++ b/examples/lab/variables.tf
@@ -22,3 +22,8 @@ variable "send_invites" {
   default     = true
 }
 
+variable "csv_file" {
+  type        = string
+  description = "Path to a CSV file containing a list of projects to provision: email,metro,plan. Email address is used as the project name and the collaborator. Metro and plan are used to provision the project."
+  default     = "users.csv"
+}


### PR DESCRIPTION
Fixes provisioning problems when stray spaces appear in the CSV file. Also allows the CSV file to be sourced from a different path.

Against a fully provisioned environment, this PR resulted in no new drifts.