### PR TITLE
set configurable 25m timeout for create_cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,7 @@ resource "null_resource" "create_cluster" {
     user        = "root"
     host        = equinix_metal_device.eksa_admin.network[0].address
     private_key = chomp(tls_private_key.ssh_key_pair.private_key_pem)
+    timeout     = var.create_cluster_timeout
   }
 
   provisioner "file" {

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,8 @@ variable "permit_root_ssh_password" {
   default     = false
   type        = bool
 }
+
+variable "create_cluster_timeout" {
+  description = "Time to wait for the create_cluster phase (example: 25m)"
+  default     = "25m"
+}


### PR DESCRIPTION
The 60m default is too long. Success can be known within 25m (generally 16m).