### PR TITLE
Use static interface names

### DIFF
--- a/examples/deploy/main.tf
+++ b/examples/deploy/main.tf
@@ -13,20 +13,21 @@ terraform {
 }
 
 module "eksa" {
-  source                  = "../.."
-  metal_api_token         = var.metal_api_token
-  project_id              = var.project_id
-  cluster_name            = var.cluster_name
-  metro                   = var.metro
-  provisioner_device_type = var.provisioner_device_type
-  node_device_os          = var.node_device_os
-  cp_device_type          = var.cp_device_type
-  cp_device_count         = var.cp_device_count
-  dp_device_type          = var.dp_device_type
-  dp_device_count         = var.dp_device_count
-  tags                    = var.tags
-  eksa_version            = var.eksa_version
-  bottlerocket_image_url  = var.bottlerocket_image_url
-  tinkerbell_images       = var.tinkerbell_images
+  source                   = "../.."
+  metal_api_token          = var.metal_api_token
+  project_id               = var.project_id
+  cluster_name             = var.cluster_name
+  metro                    = var.metro
+  provisioner_device_type  = var.provisioner_device_type
+  node_device_os           = var.node_device_os
+  cp_device_type           = var.cp_device_type
+  cp_device_count          = var.cp_device_count
+  dp_device_type           = var.dp_device_type
+  dp_device_count          = var.dp_device_count
+  tags                     = var.tags
+  eksa_version             = var.eksa_version
+  bottlerocket_image_url   = var.bottlerocket_image_url
+  tinkerbell_images        = var.tinkerbell_images
+  permit_root_ssh_password = var.permit_root_ssh_password
+  create_cluster_timeout   = var.create_cluster_timeout
 }
-

--- a/examples/deploy/variables.tf
+++ b/examples/deploy/variables.tf
@@ -89,3 +89,14 @@ variable "tinkerbell_images" {
     reboot     = optional(string, "public.ecr.aws/eks-anywhere/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-17")
   })
 }
+
+variable "permit_root_ssh_password" {
+  description = "Enable root SSH logins via password. This is intended for lab environments."
+  default     = false
+  type        = bool
+}
+
+variable "create_cluster_timeout" {
+  description = "Time to wait for the create_cluster phase (example: 25m)"
+  default     = "25m"
+}

--- a/examples/lab/main.tf
+++ b/examples/lab/main.tf
@@ -33,5 +33,4 @@ module "lab" {
   dp_device_type           = trimspace(each.value.plan)
   permit_root_ssh_password = var.permit_root_ssh_password
   send_invites             = var.send_invites
-  plan_nic                 = var.plan_nic
 }

--- a/examples/lab/variables.tf
+++ b/examples/lab/variables.tf
@@ -27,13 +27,3 @@ variable "csv_file" {
   description = "Path to a CSV file containing a list of projects to provision: email,metro,plan. Email address is used as the project name and the collaborator. Metro and plan are used to provision the project."
   default     = "users.csv"
 }
-
-variable "plan_nic" {
-  description = "Map of plans to expected NIC device name."
-  default = {
-    "m3.small.x86"  = "enp1s0f0np0"
-    "c2.medium.x86" = "enp131s0f0np0"
-  }
-  type = map(string)
-}
-

--- a/examples/project-collaborator/main.tf
+++ b/examples/project-collaborator/main.tf
@@ -49,7 +49,6 @@ module "eksa" {
   cp_device_type           = var.cp_device_type
   dp_device_type           = var.dp_device_type
   permit_root_ssh_password = var.permit_root_ssh_password
-  plan_nic                 = var.plan_nic
 }
 
 resource "equinix_metal_device" "addon_eksa_node_dp" {

--- a/examples/project-collaborator/variables.tf
+++ b/examples/project-collaborator/variables.tf
@@ -57,12 +57,3 @@ variable "permit_root_ssh_password" {
   default     = false
   type        = bool
 }
-
-variable "plan_nic" {
-  description = "Map of plans to expected NIC device name."
-  default = {
-    "m3.small.x86"  = "enp1s0f0np0"
-    "c2.medium.x86" = "enp131s0f0np0"
-  }
-  type = map(string)
-}

--- a/main.tf
+++ b/main.tf
@@ -262,7 +262,6 @@ resource "null_resource" "create_cluster" {
       TINKERBELL_IMAGE_IMAGE2DISK = var.tinkerbell_images.image2disk,
       TINKERBELL_IMAGES_WRITEFILE = var.tinkerbell_images.writefile,
       TINKERBELL_IMAGES_REBOOT    = var.tinkerbell_images.reboot
-      NIC_NAME                    = replace(var.plan_nic[var.cp_device_type], ".", "-")
     })
   }
 
@@ -276,7 +275,6 @@ resource "null_resource" "create_cluster" {
       TINKERBELL_IMAGE_IMAGE2DISK = var.tinkerbell_images.image2disk,
       TINKERBELL_IMAGES_WRITEFILE = var.tinkerbell_images.writefile,
       TINKERBELL_IMAGES_REBOOT    = var.tinkerbell_images.reboot
-      NIC_NAME                    = replace(var.plan_nic[var.dp_device_type], ".", "-")
     })
   }
 

--- a/tinkerbelltemplateconfig.tftpl
+++ b/tinkerbelltemplateconfig.tftpl
@@ -25,7 +25,7 @@ spec:
 
             # "eno1" is the interface name
             # Users may turn on dhcp4 and dhcp6 via boolean
-            [${NIC_NAME}]
+            [eth0]
             dhcp4 = true
             dhcp6 = false
             # Define this interface as the "primary" interface
@@ -49,6 +49,9 @@ spec:
           BOOTCONFIG_CONTENTS: |
             kernel {
                 console = "ttyS1,115200n8"
+            }
+            init {
+                net.ifnames=0
             }
           DEST_DISK: /dev/sda12
           DEST_PATH: /bootconfig.data

--- a/variables.tf
+++ b/variables.tf
@@ -88,16 +88,6 @@ variable "tinkerbell_images" {
     reboot     = optional(string, "public.ecr.aws/eks-anywhere/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-17")
   })
 }
-
-variable "plan_nic" {
-  description = "Map of plans to expected NIC device name."
-  default = {
-    "m3.small.x86"  = "enp1s0f0np0"
-    "c2.medium.x86" = "enp131s0f0np0"
-  }
-  type = map(string)
-}
-
 variable "permit_root_ssh_password" {
   description = "Enable root SSH logins via password. This is intended for lab environments."
   default     = false


### PR DESCRIPTION
- Change the boot template to use static interface names by passing net.ifnames=0 to the init argument.
- Update the terraform project to just use eth0 for the interface name.
- Add a couple recently added variables to the lab, deploy, and project-collaborator examples.