### PR TITLE
update the eks-a version and release number in the manual instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ We've now provided the `eksa-admin` machine with all of the variables and config
    ```
 
    ```sh
-   export EKSA_RELEASE="0.11.3" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=20
+   export EKSA_RELEASE="0.14.2" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=29
    curl "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/${RELEASE_NUMBER}/artifacts/eks-a/v${EKSA_RELEASE}/${OS}/amd64/eksctl-anywhere-v${EKSA_RELEASE}-${OS}-amd64.tar.gz" \
       --silent --location \
       | tar xz ./eksctl-anywhere


### PR DESCRIPTION
update the eks-a version and release number in the manual instructions to match the changes made in the Terraform install.

Follow up to #74 